### PR TITLE
7 simplify serialisation of content in patch operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ strum = "0.25.0"
 strum_macros = "0.25.2"
 num-traits = "0.2.16"
 regex = "1.9.3"
-serde-aux = "4.2.0"
 derive_builder = "0.12.0"
 geojson = "0.24.1"
 fake = "2.8.0"
@@ -60,11 +59,12 @@ chrono = { version = "0.4.26", features = ["serde"] }
 chrono-tz = "0.8.3"
 serde = { version = "1.0.185", features = ["derive"] }
 serde_json = "1.0.105"
+serde-aux = "4.2.0"
 async-trait = "0.1.73"
 thiserror = "1.0.47"
 uuid = "1.4.1"
 tokio = { version = "1.32.0", features = ["full"] }
-typed-builder = "0.15.2"
+typed-builder = "0.16.0"
 rand = "0.8.5"
 
 # [dev-dependencies]

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -16,7 +16,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 geo = { workspace = true }
 chrono = { workspace = true }
-serde-aux = { workspace = true }
 typed-builder = { workspace = true }
 
 [lib]

--- a/models/src/models/spaceship.rs
+++ b/models/src/models/spaceship.rs
@@ -38,22 +38,3 @@ pub struct TestRawId {
     pub id: SurrealId<Self, i32>,
     pub name: String,
 }
-
-// // Rust doc test compile fail
-// /// ```rust, compile_fail
-// /// use surreal_models::models::spaceship::SpaceShip;
-// /// let result: SurrealId<SpaceShip, i32> = TestRawId::create_id("dff");
-// /// ```
-// /// ```rust
-// /// use surreal_models::models::spaceship::SpaceShip;
-// /// let result: SurrealId<SpaceShip, i32> = TestRawId::create_id(112);
-// /// ```
-// fn ere() {
-//     let x = SpaceShip::default().get_id();
-//     // let xx: SurrealId<SpaceShip, &str> = SpaceShip::create_id("dff");
-//
-//     let c = TestRawId {
-//         id: TestRawId::create_id(34),
-//         name: "dff".to_string(),
-//     };
-// }

--- a/models/src/models/weapon.rs
+++ b/models/src/models/weapon.rs
@@ -2,8 +2,6 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use surreal_orm::{Node, Object, SurrealId, SurrealSimpleId};
 
-use serde_aux::prelude::deserialize_number_from_string;
-
 // Weapon
 #[derive(Node, Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
@@ -50,8 +48,6 @@ pub struct Rocket {
 #[surreal_orm(table_name = "weapon_stats")]
 pub struct WeaponStats {
     pub id: SurrealSimpleId<Self>,
-
-    #[serde(deserialize_with = "deserialize_number_from_string")]
     pub average_strength: f64,
 }
 
@@ -60,7 +56,6 @@ pub struct WeaponStats {
 #[surreal_orm(table_name = "account")]
 pub struct Account {
     pub id: SurrealId<Self, String>,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
     pub balance: f64,
 }
 
@@ -69,6 +64,5 @@ pub struct Account {
 #[surreal_orm(table_name = "balance")]
 pub struct Balance {
     pub id: SurrealId<Self, String>,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
     pub amount: f64,
 }

--- a/query-builder/src/statements/create.rs
+++ b/query-builder/src/statements/create.rs
@@ -8,12 +8,12 @@
 use std::marker::PhantomData;
 
 use serde::{de::DeserializeOwned, Serialize};
-use surrealdb::sql;
 
 use crate::{
+    derive_binding_and_errors_from_value,
     traits::{
-        Binding, BindingsList, Buildable, Erroneous, Node, Parametric, Queryable,
-        ReturnableDefault, ReturnableStandard,
+        BindingsList, Buildable, Erroneous, Node, Parametric, Queryable, ReturnableDefault,
+        ReturnableStandard,
     },
     types::{DurationLike, ReturnType},
     ErrorList, Setter, ToRaw,
@@ -113,10 +113,10 @@ where
     ///     });
     /// ```
     pub fn content(mut self, content: T) -> CreateStatement<T> {
-        let sql_value = sql::to_value(&content).unwrap();
-        let binding = Binding::new(sql_value);
+        let (binding, errors) = derive_binding_and_errors_from_value(&content);
         self.content = binding.get_param_dollarised();
         self.bindings.push(binding);
+        self.errors.extend(errors);
 
         CreateStatement(self)
     }

--- a/query-builder/src/statements/create.rs
+++ b/query-builder/src/statements/create.rs
@@ -130,6 +130,17 @@ where
     ///
     /// # Examples
     ///
+    /// Setting multiple fields by using the `object!` macro. Forces you to set all fields
+    /// and makes sure they are all typed correctly. This is the recommended approach.
+    /// ```rust, ignore
+    /// assert_eq!(create::<User>()
+    ///             .set(object!(User {
+    ///                 name: "Oyelowo",
+    ///                 age: 192
+    ///             })
+    ///         ).to_raw().build(), "Create user SET name='Oyelowo', age=192")
+    /// ```
+    ///
     /// Setting single field
     /// ```rust, ignore
     /// assert_eq!(create::<User>().set(name.equal("Oyelowo")).to_raw().build(), "CREATE user SET name='Oyelowo'")
@@ -138,8 +149,10 @@ where
     /// Setting multiple fields by chaining `set` method
     /// ```rust, ignore
     /// assert_eq!(create::<User>()
-    ///             .set(name.equal_to("Oyelowo"))
-    ///             .set(age.equal_to(192))
+    ///             .set([
+    ///                 name.equal_to("Oyelowo"),
+    ///                 age.equal_to(192)
+    ///             ])
     ///         ).to_raw().build(), "Create user SET name='Oyelowo', age=192")
     /// ```
     ///

--- a/query-builder/src/statements/relate.rs
+++ b/query-builder/src/statements/relate.rs
@@ -105,28 +105,29 @@ where
     /// # Examples
     ///
     /// ```rust, ignore
-    /// // set a field number. Generates  =
-    /// updater(score).equals(5)
+    /// // Set fields using a helper macro function:
+    /// .set(object_partial!(Weapon {
+    ///     id: weapon_id.clone(),
+    ///     name: "Laser".to_string()
+    /// }))
+    ///
+    /// // Set multiple fields as an array or vector:
+    /// .set([name.equal_to("Laser"), damage.increment_by(100)]);
+    ///
+    /// // set a single field number. Generates  =
+    /// .set(score.equal_to(5))
     ///
     /// // increment a field number. Generates  +=
-    /// updater(score).increment_by(5)
-    /// // or alias
-    /// updater(score).plus_equal(5)
+    /// .set(score.increment_by(5))
     ///
     /// // decrement a field number. Generates  -=
-    /// updater(score).decrement_by(5)
-    /// // or alias
-    /// updater(score).minus_equal(5)
+    /// .set(score.decrement_by(5))
     ///
     /// // add to an array. Generates  +=
-    /// updater(friends_names).append("Oyelowo")
-    /// // or alias
-    /// updater(friends_names).plus_equal("Oyelowo")
+    /// .set(friends_names.append("Oyelowo"))
     ///
     /// // remove value from an array. Generates  -=
-    /// updater(friends_names).remove("Oyedayo")
-    /// // or alias
-    /// updater(friends_names).minus_equal("Oyedayo")
+    /// .set(friends_names.remove("Oyedayo"))
     /// ```
     pub fn set(mut self, settables: impl Into<Vec<Setter>>) -> Self {
         let settable: Vec<Setter> = settables.into();

--- a/query-builder/src/statements/relate.rs
+++ b/query-builder/src/statements/relate.rs
@@ -17,10 +17,10 @@
 use std::marker::PhantomData;
 
 use serde::{de::DeserializeOwned, Serialize};
-use surrealdb::sql;
 
 use crate::{
-    traits::{Binding, BindingsList, Buildable, Edge, Erroneous, ErrorList, Parametric, Queryable},
+    derive_binding_and_errors_from_value,
+    traits::{BindingsList, Buildable, Edge, Erroneous, ErrorList, Parametric, Queryable},
     types::{DurationLike, ReturnType},
     ReturnableDefault, ReturnableStandard, Setter, ToRaw,
 };
@@ -92,10 +92,10 @@ where
 {
     /// Set a serailizable surrealdb edge model. It must implement the Edge trait.
     pub fn content(mut self, content: T) -> Self {
-        let sql_value = sql::to_value(&content).unwrap();
-        let binding = Binding::new(sql_value);
+        let (binding, errors) = derive_binding_and_errors_from_value(&content);
         self.content_param = Some(binding.get_param_dollarised().to_owned());
         self.bindings.push(binding);
+        self.errors.extend(errors);
         self
     }
 

--- a/query-builder/src/statements/update.rs
+++ b/query-builder/src/statements/update.rs
@@ -23,9 +23,10 @@ use serde::{de::DeserializeOwned, Serialize};
 use surrealdb::sql;
 
 use crate::{
-    Binding, BindingsList, Buildable, Conditional, DurationLike, Erroneous, ErrorList, Filter,
-    Model, Parametric, PatchOp, Queryable, ReturnType, ReturnableDefault, ReturnableStandard,
-    Setter, SurrealId, SurrealSimpleId, SurrealUlid, SurrealUuid, ToRaw,
+    derive_binding_and_errors_from_value, Binding, BindingsList, Buildable, Conditional,
+    DurationLike, Erroneous, ErrorList, Filter, Model, Parametric, PatchOp, Queryable, ReturnType,
+    ReturnableDefault, ReturnableStandard, Setter, SurrealId, SurrealSimpleId, SurrealUlid,
+    SurrealUuid, ToRaw,
 };
 
 /// Creates a new UPDATE statement.
@@ -298,25 +299,19 @@ where
     /// Specify the full record data using the CONTENT keyword. The content must be serializable
     /// and implement Model trait.
     pub fn content(mut self, content: T) -> UpdateStatement<T> {
-        // let sql_value = sql::json(
-        //     &sql::to_value(&content)
-        //         .expect("Problem converting to value")
-        //         .to_string(),
-        // )
-        // .expect("Problem converting to JSON");
-        let sql_value = sql::to_value(&content).unwrap();
-        let binding = Binding::new(sql_value);
+        let (binding, errors) = derive_binding_and_errors_from_value(&content);
         self.content = Some(binding.get_param_dollarised());
         self.bindings.push(binding);
+        self.errors.extend(errors);
         self.into()
     }
 
     /// merge-update only specific fields by using the MERGE keyword and specifying only the fields which are to be updated.
     pub fn merge(mut self, merge: impl Serialize) -> UpdateStatement<T> {
-        let sql_value = sql::to_value(&merge).unwrap();
-        let binding = Binding::new(sql_value);
+        let (binding, errors) = derive_binding_and_errors_from_value(&merge);
         self.merge = Some(binding.get_param_dollarised());
         self.bindings.push(binding);
+        self.errors.extend(errors);
         self.into()
     }
 
@@ -324,10 +319,10 @@ where
     /// Fully replaces weapon table with completely new object and data. This will remove all fields
     /// that are not present in the new object. This is a destructive operation.
     pub fn replace(mut self, replacement: impl Serialize) -> UpdateStatement<T> {
-        let sql_value = sql::to_value(&replacement).unwrap();
-        let binding = Binding::new(sql_value);
+        let (binding, errors) = derive_binding_and_errors_from_value(&replacement);
         self.replace = Some(binding.get_param_dollarised());
         self.bindings.push(binding);
+        self.errors.extend(errors);
         self.into()
     }
 

--- a/query-builder/src/statements/update.rs
+++ b/query-builder/src/statements/update.rs
@@ -332,6 +332,33 @@ where
     /// To increment a numeric value, or to add an item to an array,
     /// use the `append` or incremenet (i.e +=) operator. To decrement a numeric value,
     /// or to remove an value from an array, use the `decrement` or `remove` (i.e -=) operator.
+    ///
+    /// # Examples
+    ///
+    /// ```rust, ignore
+    /// // Set fields using a helper macro function:
+    /// .set(object_partial!(Weapon {
+    ///     id: weapon_id.clone(),
+    ///     name: "Laser".to_string()
+    /// }))
+    ///
+    /// // Set multiple fields as an array or vector:
+    /// .set([name.equal_to("Laser"), damage.increment_by(100)]);
+    ///
+    /// // set a single field number. Generates  =
+    /// .set(score.equal_to(5))
+    ///
+    /// // increment a field number. Generates  +=
+    /// .set(score.increment_by(5))
+    ///
+    /// // decrement a field number. Generates  -=
+    /// .set(score.decrement_by(5))
+    ///
+    /// // add to an array. Generates  +=
+    /// .set(friends_names.append("Oyelowo"))
+    ///
+    /// // remove value from an array. Generates  -=
+    /// .set(friends_names.remove("Oyedayo"))
     pub fn set(mut self, settables: impl Into<Vec<Setter>>) -> UpdateStatement<T> {
         let settable: Vec<Setter> = settables.into();
 


### PR DESCRIPTION
- Consistently handle serialization of values in create, update, relate statements, and patch operations.
- Update Readme
- Remove `serde-aux` usage