### PR TITLE
Support compile time checked query with query! macro

### DIFF
--- a/orm-tests/tests/query_macro.rs
+++ b/orm-tests/tests/query_macro.rs
@@ -1,0 +1,25 @@
+use surreal_orm::query;
+
+#[test]
+fn test_query_macro() {
+    let query = query!("SELECT name, age, * FROM users");
+    assert_eq!(query, "SELECT name, age, * FROM users");
+}
+
+#[test]
+fn test_query_macro_with_params() {
+    let query = query!("SELECT name, age, * FROM users WHERE name = $1 AND name = 'Oyelowo'");
+    assert_eq!(
+        query,
+        "SELECT name, age, * FROM users WHERE name = $1 AND name = 'Oyelowo'"
+    );
+}
+
+#[test]
+fn test_query_macro_with_graph() {
+    let query = query!("SELECT ->purchased->product<-purchased<-person->purchased->product FROM person:tobie PARALLEL");
+    assert_eq!(
+        query,
+        "SELECT ->purchased->product<-purchased<-person->purchased->product FROM person:tobie PARALLEL"
+    );
+}

--- a/orm/src/lib.rs
+++ b/orm/src/lib.rs
@@ -200,6 +200,9 @@ pub use surreal_derive::Node;
 #[doc = include_str!("docs/object_field_attributes.md")]
 pub use surreal_derive::Object;
 
+// #[doc = include_str!("docs/query_description.md")]
+pub use surreal_derive::query;
+
 #[doc(hidden)]
 // pub use serde;
 pub use surreal_query_builder::*;


### PR DESCRIPTION
## Description
Support compile-time checked query with `query!` macro:

```rs
use surreal_orm::query;

#[test]
fn test_query_macro() {
    let query = query!("SELECT name, age, * FROM users");
    assert_eq!(query, "SELECT name, age, * FROM users");
}

#[test]
fn test_query_macro_with_params() {
    let query = query!("SELECT name, age, * FROM users WHERE name = $1 AND name = 'Oyelowo'");
    assert_eq!(
        query,
        "SELECT name, age, * FROM users WHERE name = $1 AND name = 'Oyelowo'"
    );
}

#[test]
fn test_query_macro_with_graph() {
    let query = query!("SELECT ->purchased->product<-purchased<-person->purchased->product FROM person:tobie PARALLEL");
    assert_eq!(
        query,
        "SELECT ->purchased->product<-purchased<-person->purchased->product FROM person:tobie PARALLEL"
    );
}

```