### PR TITLE
Implement matches and matches_with_ref

### DIFF
--- a/query-builder/src/statements/for_loop.rs
+++ b/query-builder/src/statements/for_loop.rs
@@ -376,7 +376,6 @@ mod tests {
         let for_loop = for_(__name).in_(vec!["Oyelowo", "Oyedayo"]).block(block! {
             LET nick_name = select(user_name).from_only(person_table).where_(user_name.eq(__name));
 
-
             select(All).from(person_table).where_(user_name.eq(nick_name));
         });
 


### PR DESCRIPTION
## Description

- Support matches operation:



@@ or @[ref]@ | Checks whether the terms are found in a full-text indexed field
-- | --


[@@ or @[ref]@](https://surrealdb.com/docs/surrealql/operators#matches)	Checks whether the terms are found in a full-text indexed field
