### PR TITLE
47 support optional and complex vector type autoinferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,63 @@ initial balances. We then increment the balance of the first account and
 decrement the balance of the second account by the same amount. Finally, we
 commit the transaction and then verify that the balances were updated correctly.
 
+## `query!` Macro
+
+The `query!` macro allows for writing SQL queries directly in Rust, providing
+automatic handling of placeholders and bindings, ensuring type safety, and
+reducing repetitive boilerplate code.
+
+### Usage
+
+With the `query!` macro, you can easily construct and execute SQL queries:
+
+- **Basic Query**:
+
+  ```rust
+  let query = query!(db, "SELECT * FROM users").await;
+  let query = query!(db, "SELECT * FROM users", {}).await;
+  ```
+
+- **With Placeholders**:
+
+  ```rust
+  let username = "Oyelowo";
+  let query = query!(db, "SELECT name, age FROM users WHERE age > $age AND name = $ame", {
+      age : 102,
+      ame : username
+  })
+  .await;
+  ```
+
+- **Multiple Queries**:
+  ```rust
+  let queries = query!(
+      db,
+      [
+          "SELECT * FROM users WHERE score = $score",
+          "CREATE user:oyelowo SET name = $name, company = $company_name, skills = $skills"
+      ],
+      {
+          score: 100,
+          name: "Oyelowo",
+          skills: vec!["Rust", "python", "typescript"],
+          company_name: "Codebreather"
+      }
+  )
+  .await;
+  ```
+
+### Benefits
+
+The `query!` macro offers several benefits, including:
+
+- **Developer Efficiency**: Reduce the time spent writing and debugging SQL
+  queries.
+- **Code Clarity**: Achieve clearer and more maintainable code with direct SQL
+  queries in Rust.
+- **Error Reduction**: Minimize the potential for runtime errors and SQL
+  injection vulnerabilities.
+
 ## Conclusion
 
 This concludes the basic usage and features of the Surreal ORM library. You can

--- a/derive/src/migration/mod.rs
+++ b/derive/src/migration/mod.rs
@@ -1,3 +1,10 @@
+/*
+ * Author: Oyelowo Oyedayo
+ * Email: oyelowo.oss@gmail.com
+ * Copyright (c) 2023 Oyelowo Oyedayo
+ * Licensed under the MIT license
+ */
+
 use migrator::{MigrationConfig, MigrationError, MigrationFlag, Mode};
 use proc_macro::TokenStream;
 use quote::quote;

--- a/derive/src/models/attributes.rs
+++ b/derive/src/models/attributes.rs
@@ -474,21 +474,9 @@ impl MyFieldReceiver {
             // let content
             let ft_string = field_type.to_string();
             Ok(Some(FieldTypeDerived {
-                // TODO: Remove commented out codde
-                // field_type: quote!(#type_.parse::<#crate_name::FieldType>()
-                //                                             .expect("Must have been checked at compile time. If not, this is a bug. Please report")),
                 field_type: quote!(#ft_string.parse::<#crate_name::FieldType>()
                                                             .expect("Must have been checked at compile time. If not, this is a bug. Please report")),
-                // TODO: Fix me
-                // field_type: quote!(#type_.into_inner()),
-
-                // field_item_type: self.item_type.as_ref().map(|item_type| {
-                //     let item_type = &item_type.0;
-                //     quote!(#item_type.parse::<#crate_name::FieldType>()
-                //         .expect("Must have been checked at compile time. If not, this is a bug. Please report"))
-                // }),
                 static_assertion: quote!( # ( #static_assertions ) *),
-                // #( # define_array_field_item_methods) *
             }))
         } else if self
             .rust_type()
@@ -499,13 +487,11 @@ impl MyFieldReceiver {
                 model_type,
             )))
         } else {
-            // TODO: consider a syn::Error here
-            panic!(
+            return Err(syn::Error::new_spanned(field_name_normalized, format!(
                 r#"Unable to infer database type for the field. Type must be provided for field - {}.\
             e.g use the annotation #[surreal_orm(type_="int")] to provide the type explicitly."#,
                 field_name_normalized
-            );
-            // Ok(None)
+            ).as_str()).into());
         }
     }
 

--- a/derive/src/models/attributes.rs
+++ b/derive/src/models/attributes.rs
@@ -25,7 +25,7 @@ use darling::{ast::Data, util, FromDeriveInput, FromField, FromMeta, ToTokens};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use surreal_query_builder::FieldType;
-use syn::{Ident, Lit, LitStr, Path, Type};
+use syn::{Ident, Lit, LitStr, Path};
 
 #[derive(Debug, Clone)]
 pub struct Rename {
@@ -220,8 +220,6 @@ impl MyFieldReceiver {
     ) -> ExtractorResult<Option<FieldTypeDerived>> {
         let mut static_assertions = vec![];
         let crate_name = get_crate_name(false);
-
-        let rust_type = FieldRustType::new(self.ty.clone(), Default::default());
 
         if let Some(type_) = &self.type_ {
             let field_type = type_.deref();
@@ -591,19 +589,17 @@ impl MyFieldReceiver {
 
     pub fn is_numeric(&self) -> bool {
         let field_type = self.type_.clone().map_or(FieldType::Any, |t| t.0);
-        let explicit_ty_is_numeric = match field_type {
-            FieldType::Int | FieldType::Float | FieldType::Decimal | FieldType::Number => true,
-            _ => false,
-        };
+        let explicit_ty_is_numeric = matches!(
+            field_type,
+            FieldType::Int | FieldType::Float | FieldType::Decimal | FieldType::Number
+        );
         explicit_ty_is_numeric || self.rust_type().is_numeric()
     }
 
     pub fn is_list(&self) -> bool {
         let field_type = self.type_.clone().map_or(FieldType::Any, |t| t.0);
-        let explicit_ty_is_list = match field_type {
-            FieldType::Array(_, _) | FieldType::Set(_, _) => true,
-            _ => false,
-        };
+        let explicit_ty_is_list =
+            matches!(field_type, FieldType::Array(_, _) | FieldType::Set(_, _));
         explicit_ty_is_list
             || self.rust_type().is_list()
             || self.type_.as_ref().map_or(false, |t| t.deref().is_array())

--- a/derive/src/models/attributes.rs
+++ b/derive/src/models/attributes.rs
@@ -598,6 +598,18 @@ impl MyFieldReceiver {
         explicit_ty_is_numeric || self.rust_type().is_numeric()
     }
 
+    pub fn is_list(&self) -> bool {
+        let field_type = self.type_.clone().map_or(FieldType::Any, |t| t.0);
+        let explicit_ty_is_list = match field_type {
+            FieldType::Array(_, _) | FieldType::Set(_, _) => true,
+            _ => false,
+        };
+        explicit_ty_is_list
+            || self.rust_type().is_list()
+            || self.type_.as_ref().map_or(false, |t| t.deref().is_array())
+            || self.link_many.is_some()
+    }
+
     pub fn rust_type(&self) -> FieldRustType {
         let attrs = Attributes {
             link_one: self.link_one.as_ref(),

--- a/derive/src/models/attributes.rs
+++ b/derive/src/models/attributes.rs
@@ -343,25 +343,6 @@ impl MyFieldReceiver {
                                 .into());
                             }
                         }
-                    } else if let FieldType::Array(item_type, _) = field_type {
-                        // TODO: see if we can allow this
-                        let rust_type = FieldRustType::new(self.ty.clone(), Default::default());
-                        if item_type.is_any()
-                            && !rust_type.type_is_inferrable(field_name_normalized)
-                        {
-                            let err = format!(
-                                "Not able to infer array content type. Content type must 
-                    be provided when type is array and the compiler cannot infer the type. 
-                    Please, provide `item_type` for the field - {}. 
-                    e.g `#[surreal_orm(type=array, item_type=\"int\")]`",
-                                &field_name_normalized
-                            );
-                            return Err(syn::Error::new_spanned(
-                                field_name_normalized,
-                                err.as_str(),
-                            )
-                            .into());
-                        }
                     }
                 }
                 _ => {}
@@ -515,14 +496,15 @@ impl MyFieldReceiver {
             .rust_type()
             .type_is_inferrable(&field_name_normalized.to_string())
         {
-            // rust_type.infer_surreal_type_heuristically(field_name_normalized)
             Ok(Some(
                 self.rust_type()
                     .infer_surreal_type_heuristically(field_name_normalized),
             ))
         } else {
+            // TODO: consider a syn::Error here
             panic!(
-                "Type must be provided for field - {}",
+                r#"Unable to infer database type for the field. Type must be provided for field - {}.\
+            e.g use the annotation #[surreal_orm(type_="int")] to provide the type explicitly."#,
                 field_name_normalized
             );
             // Ok(None)

--- a/derive/src/models/attributes.rs
+++ b/derive/src/models/attributes.rs
@@ -494,10 +494,10 @@ impl MyFieldReceiver {
             .rust_type()
             .type_is_inferrable(&field_name_normalized.to_string())
         {
-            Ok(Some(
-                self.rust_type()
-                    .infer_surreal_type_heuristically(field_name_normalized),
-            ))
+            Ok(Some(self.rust_type().infer_surreal_type_heuristically(
+                field_name_normalized,
+                model_type,
+            )))
         } else {
             // TODO: consider a syn::Error here
             panic!(

--- a/derive/src/models/field_rust_type.rs
+++ b/derive/src/models/field_rust_type.rs
@@ -8,7 +8,7 @@
 use quote::{format_ident, quote};
 use syn::{self, Type};
 
-use super::{attributes::FieldTypeDerived, get_crate_name};
+use super::{attributes::FieldTypeDerived, get_crate_name, parser::DataType};
 
 #[derive(Debug, Default)]
 pub struct Attributes<'a> {
@@ -319,6 +319,7 @@ impl<'a> FieldRustType<'a> {
     pub fn infer_surreal_type_heuristically(
         &self,
         field_name_normalized: &str,
+        model_type: &DataType,
     ) -> FieldTypeDerived {
         let crate_name = get_crate_name(false);
         let ty = &self.ty;
@@ -355,7 +356,7 @@ impl<'a> FieldRustType<'a> {
                         attributes: Default::default(),
                     };
 
-                    item.infer_surreal_type_heuristically("")
+                    item.infer_surreal_type_heuristically("", model_type)
                 })
                 .unwrap_or_default();
 
@@ -381,7 +382,7 @@ impl<'a> FieldRustType<'a> {
                         attributes: Default::default(),
                     };
 
-                    item.infer_surreal_type_heuristically("")
+                    item.infer_surreal_type_heuristically("", model_type)
                 })
                 .unwrap_or_default();
 
@@ -434,8 +435,9 @@ impl<'a> FieldRustType<'a> {
                     field_type: quote!(#crate_name::FieldType::Record(::std::vec![Self::table_name()])),
                     static_assertion: quote!(),
                 }
-                // TODO: Only do this for Edge
-            } else if field_name_normalized == "out" || field_name_normalized == "in" {
+            } else if (field_name_normalized == "out" || field_name_normalized == "in")
+                && matches!(model_type, DataType::Edge)
+            {
                 // An edge might be shared by multiple In/Out nodes. So, default to any type of
                 // record for edge in and out
                 FieldTypeDerived {

--- a/derive/src/models/field_rust_type.rs
+++ b/derive/src/models/field_rust_type.rs
@@ -403,7 +403,10 @@ impl<'a> FieldRustType<'a> {
             let inner_static_assertion = inner_item.static_assertion;
             FieldTypeDerived {
                 field_type: quote!(#crate_name::FieldType::Array(::std::boxed::Box::new(#inner_type), ::std::option::Option::None)),
-                static_assertion: quote!(#crate_name::validators::assert_is_vec::<#ty>();),
+                static_assertion: quote!(
+                            #crate_name::validators::assert_is_vec::<#ty>();
+                            #inner_static_assertion
+                ),
                 // quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Array>);),
             }
         // } else if self.raw_type_is_hash_set() || self.type_.is_some() {

--- a/derive/src/models/field_rust_type.rs
+++ b/derive/src/models/field_rust_type.rs
@@ -356,7 +356,7 @@ impl<'a> FieldRustType<'a> {
                         attributes: Default::default(),
                     };
 
-                    item.infer_surreal_type_heuristically("", model_type)
+                    item.infer_surreal_type_heuristically(field_name_normalized, model_type)
                 })
                 .unwrap_or_default();
 
@@ -382,7 +382,7 @@ impl<'a> FieldRustType<'a> {
                         attributes: Default::default(),
                     };
 
-                    item.infer_surreal_type_heuristically("", model_type)
+                    item.infer_surreal_type_heuristically(field_name_normalized, model_type)
                 })
                 .unwrap_or_default();
 
@@ -485,10 +485,14 @@ impl<'a> FieldRustType<'a> {
                     static_assertion: quote!(),
                 }
             } else {
-                FieldTypeDerived {
-                    field_type: quote!(#crate_name::FieldType::Any),
-                    static_assertion: quote!(),
-                }
+                // FieldTypeDerived {
+                //     field_type: quote!(#crate_name::FieldType::Any),
+                //     static_assertion: quote!(),
+                // }
+                panic!(
+                    "Could not infer type for the field {}",
+                    field_name_normalized
+                );
             }
         }
     }

--- a/derive/src/models/field_rust_type.rs
+++ b/derive/src/models/field_rust_type.rs
@@ -510,8 +510,8 @@ impl<'a> FieldRustType<'a> {
             } else {
                 FieldTypeDerived {
                     field_type: quote!(#crate_name::FieldType::Any),
-                    // static_assertion: quote!(),
-                    static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Value>);),
+                    static_assertion: quote!(),
+                    // static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Value>);),
                 }
             }
         }

--- a/derive/src/models/field_rust_type.rs
+++ b/derive/src/models/field_rust_type.rs
@@ -1,3 +1,10 @@
+/*
+ * Author: Oyelowo Oyedayo
+ * Email: oyelowo.oss@gmail.com
+ * Copyright (c) 2023 Oyelowo Oyedayo
+ * Licensed under the MIT license
+ */
+
 use quote::{format_ident, quote};
 use syn::{self, Type};
 
@@ -311,8 +318,6 @@ impl<'a> FieldRustType<'a> {
 
     pub fn infer_surreal_type_heuristically(
         &self,
-        // ty: &Type,
-        // struct_name_ident_str: &String,
         field_name_normalized: &str,
     ) -> FieldTypeDerived {
         let crate_name = get_crate_name(false);
@@ -321,25 +326,21 @@ impl<'a> FieldRustType<'a> {
         if self.raw_type_is_bool() {
             FieldTypeDerived {
                 field_type: quote!(#crate_name::FieldType::Bool),
-                // field_item_type: None,
                 static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<::std::primitive::bool>);),
             }
         } else if self.raw_type_is_float() {
             FieldTypeDerived {
                 field_type: quote!(#crate_name::FieldType::Float),
-                // field_item_type: None,
                 static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Number>);),
             }
         } else if self.raw_type_is_integer() {
             FieldTypeDerived {
                 field_type: quote!(#crate_name::FieldType::Int),
-                // field_item_type: None,
                 static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Number>);),
             }
         } else if self.raw_type_is_string() {
             FieldTypeDerived {
                 field_type: quote!(#crate_name::FieldType::String),
-                // field_item_type: None,
                 static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Strand>);),
             }
         } else if self.raw_type_is_optional() {
@@ -353,7 +354,6 @@ impl<'a> FieldRustType<'a> {
                         ty,
                         attributes: Default::default(),
                     };
-                    
 
                     item.infer_surreal_type_heuristically("")
                 })
@@ -364,7 +364,6 @@ impl<'a> FieldRustType<'a> {
 
             FieldTypeDerived {
                 field_type: quote!(#crate_name::FieldType::Option(::std::boxed::Box::new(#inner_type))),
-                // field_item_type: None,
                 static_assertion: quote!(
                     #crate_name::validators::assert_option::<#ty>();
                     #item_static_assertion
@@ -381,7 +380,6 @@ impl<'a> FieldRustType<'a> {
                         ty,
                         attributes: Default::default(),
                     };
-                    
 
                     item.infer_surreal_type_heuristically("")
                 })
@@ -395,15 +393,8 @@ impl<'a> FieldRustType<'a> {
                             #crate_name::validators::assert_is_vec::<#ty>();
                             #inner_static_assertion
                 ),
-                // quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Array>);),
             }
-        // } else if self.raw_type_is_hash_set() || self.type_.is_some() {
         } else if self.raw_type_is_hash_set() {
-            // let array_type = self.type_.as_ref().map(|ct| {
-            //     let ct = ct.to_string();
-            //     quote!(#ct.to_string().parse::<#crate_name::FieldType>().expect("Invalid db type"))
-            // });
-
             FieldTypeDerived {
                 field_type: quote!(#crate_name::FieldType::Set(::std::boxed::Box::new(#crate_name::FieldType::Any), ::std::option::Option::None)),
                 static_assertion: quote!(#crate_name::validators::assert_is_vec::<#ty>();),
@@ -436,7 +427,6 @@ impl<'a> FieldRustType<'a> {
                 link_many,
                 nest_array,
                 nest_object,
-                ..
             } = self.attributes;
 
             if field_name_normalized == "id" {

--- a/derive/src/models/field_rust_type.rs
+++ b/derive/src/models/field_rust_type.rs
@@ -1,6 +1,6 @@
-use proc_macro2::TokenStream;
 use quote::ToTokens;
 use quote::{format_ident, quote};
+use surreal_query_builder::FieldType;
 use syn::{self, Type};
 
 use super::attributes::MyFieldReceiver;
@@ -441,15 +441,16 @@ impl<'a> FieldRustType<'a> {
                 field_type: quote!(#crate_name::FieldType::Geometry(::std::vec![])),
                 static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Geometry>);),
             }
-        } else if let Attributes {
-            link_one,
-            link_self,
-            link_many,
-            nest_array,
-            nest_object,
-            ..
-        } = self.attributes
-        {
+        } else {
+            let Attributes {
+                link_one,
+                link_self,
+                link_many,
+                nest_array,
+                nest_object,
+                ..
+            } = self.attributes;
+
             if field_name_normalized == "id" {
                 FieldTypeDerived {
                     field_type: quote!(#crate_name::FieldType::Record(::std::vec![Self::table_name()])),
@@ -509,13 +510,9 @@ impl<'a> FieldRustType<'a> {
             } else {
                 FieldTypeDerived {
                     field_type: quote!(#crate_name::FieldType::Any),
-                    static_assertion: quote!(),
+                    // static_assertion: quote!(),
+                    static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Value>);),
                 }
-            }
-        } else {
-            FieldTypeDerived {
-                field_type: quote!(#crate_name::FieldType::Any),
-                static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Value>);),
             }
         }
     }

--- a/derive/src/models/field_rust_type.rs
+++ b/derive/src/models/field_rust_type.rs
@@ -379,7 +379,11 @@ impl<'a> FieldRustType<'a> {
                     let ty = ct.clone();
                     let item = Self {
                         ty,
-                        attributes: Default::default(),
+                        attributes: Attributes {
+                            nest_array: self.attributes.nest_array,
+                            nest_object: self.attributes.nest_object,
+                            ..Default::default()
+                        },
                     };
 
                     item.infer_surreal_type_heuristically(field_name_normalized, model_type)
@@ -467,10 +471,12 @@ impl<'a> FieldRustType<'a> {
                 }
             } else if let Some(_ref_node_type) = nest_array {
                 FieldTypeDerived {
-                    field_type: quote!(#crate_name::FieldType::Array(
-                        ::std::boxed::Box::new(#crate_name::FieldType::Any),
-                        ::std::option::Option::None
-                    )),
+                    // provide the inner type for when the array part start recursing
+                    field_type: quote!(#crate_name::FieldType::Object),
+                    // field_type: quote!(#crate_name::FieldType::Array(
+                    //     ::std::boxed::Box::new(#crate_name::FieldType::Object),
+                    //     ::std::option::Option::None
+                    // )),
                     static_assertion: quote!(),
                 }
             } else if let Some(_ref_node_type) = link_one {

--- a/derive/src/models/field_rust_type.rs
+++ b/derive/src/models/field_rust_type.rs
@@ -1,9 +1,6 @@
-use quote::ToTokens;
 use quote::{format_ident, quote};
-use surreal_query_builder::FieldType;
 use syn::{self, Type};
 
-use super::attributes::MyFieldReceiver;
 use super::{attributes::FieldTypeDerived, get_crate_name};
 
 #[derive(Debug, Default)]
@@ -27,11 +24,6 @@ impl<'a> FieldRustType<'a> {
 
     pub fn is_numeric(&self) -> bool {
         let ty = &self.ty;
-        // let surreal_field_type = match &self.type_ {
-        //     Some(ft) => ft.deref(),
-        //     None => &FieldType::Any,
-        // };
-
         let type_is_numeric = match ty {
             syn::Type::Path(ref p) => {
                 let path = &p.path;
@@ -49,10 +41,6 @@ impl<'a> FieldRustType<'a> {
         };
 
         type_is_numeric
-        // || matches!(
-        //     surreal_field_type,
-        //     FieldType::Int | FieldType::Number | FieldType::Float
-        // )
     }
 
     pub fn raw_type_is_float(&self) -> bool {
@@ -365,9 +353,9 @@ impl<'a> FieldRustType<'a> {
                         ty,
                         attributes: Default::default(),
                     };
-                    let item = item.infer_surreal_type_heuristically("");
+                    
 
-                    item
+                    item.infer_surreal_type_heuristically("")
                 })
                 .unwrap_or_default();
 
@@ -393,9 +381,9 @@ impl<'a> FieldRustType<'a> {
                         ty,
                         attributes: Default::default(),
                     };
-                    let item = item.infer_surreal_type_heuristically("");
+                    
 
-                    item
+                    item.infer_surreal_type_heuristically("")
                 })
                 .unwrap_or_default();
 
@@ -464,7 +452,7 @@ impl<'a> FieldRustType<'a> {
                     field_type: quote!(#crate_name::FieldType::Record(::std::vec![])),
                     static_assertion: quote!(),
                 }
-            } else if let Some(ref_node_type) = link_one.clone().or(link_self.clone()) {
+            } else if let Some(ref_node_type) = link_one.or(link_self) {
                 let ref_node_type = format_ident!("{ref_node_type}");
 
                 FieldTypeDerived {
@@ -478,9 +466,6 @@ impl<'a> FieldRustType<'a> {
                         ::std::boxed::Box::new(#crate_name::FieldType::Record(::std::vec![#ref_struct_name::table_name()])),
                         ::std::option::Option::None
                     )),
-                    // field_item_type: Some(
-                    //     quote!(#crate_name::FieldType::Record(#ref_struct_name::table_name())),
-                    // ),
                     static_assertion: quote!(),
                 }
             } else if let Some(_ref_node_type) = nest_object {
@@ -511,7 +496,6 @@ impl<'a> FieldRustType<'a> {
                 FieldTypeDerived {
                     field_type: quote!(#crate_name::FieldType::Any),
                     static_assertion: quote!(),
-                    // static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Value>);),
                 }
             }
         }

--- a/derive/src/models/field_rust_type.rs
+++ b/derive/src/models/field_rust_type.rs
@@ -1,0 +1,546 @@
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use quote::{format_ident, quote};
+use syn::{self, Type};
+
+use super::attributes::MyFieldReceiver;
+use super::{attributes::FieldTypeDerived, get_crate_name};
+
+#[derive(Debug, Default)]
+pub struct Attributes<'a> {
+    pub(crate) link_one: Option<&'a String>,
+    pub(crate) link_self: Option<&'a String>,
+    pub(crate) link_many: Option<&'a String>,
+    pub(crate) nest_array: Option<&'a String>,
+    pub(crate) nest_object: Option<&'a String>,
+}
+
+pub struct FieldRustType<'a> {
+    pub(crate) ty: Type,
+    pub(crate) attributes: Attributes<'a>,
+}
+
+impl<'a> FieldRustType<'a> {
+    pub fn new(ty: Type, attributes: Attributes<'a>) -> Self {
+        Self { ty, attributes }
+    }
+
+    pub fn is_numeric(&self) -> bool {
+        let ty = &self.ty;
+        // let surreal_field_type = match &self.type_ {
+        //     Some(ft) => ft.deref(),
+        //     None => &FieldType::Any,
+        // };
+
+        let type_is_numeric = match ty {
+            syn::Type::Path(ref p) => {
+                let path = &p.path;
+                path.leading_colon.is_none() && path.segments.len() == 1 && {
+                    let ident = &path.segments[0].ident.to_string();
+                    [
+                        "u8", "u16", "u32", "u64", "u128", "usize", "i8", "i16", "i32", "i64",
+                        "i128", "isize", "f32", "f64",
+                    ]
+                    .iter()
+                    .any(|&x| x == ident)
+                }
+            }
+            _ => false,
+        };
+
+        type_is_numeric
+        // || matches!(
+        //     surreal_field_type,
+        //     FieldType::Int | FieldType::Number | FieldType::Float
+        // )
+    }
+
+    pub fn raw_type_is_float(&self) -> bool {
+        match self.ty {
+            syn::Type::Path(ref p) => {
+                let path = &p.path;
+                path.leading_colon.is_none() && path.segments.len() == 1 && {
+                    let ident = &path.segments[0].ident.to_string();
+                    ["f32", "f64"].iter().any(|&x| x == ident)
+                }
+            }
+            _ => false,
+        }
+    }
+
+    pub fn raw_type_is_integer(&self) -> bool {
+        match self.ty {
+            syn::Type::Path(ref p) => {
+                let path = &p.path;
+                path.leading_colon.is_none() && path.segments.len() == 1 && {
+                    let ident = &path.segments[0].ident.to_string();
+                    [
+                        "u8", "u16", "u32", "u64", "u128", "usize", "i8", "i16", "i32", "i64",
+                        "i128", "isize",
+                    ]
+                    .iter()
+                    .any(|&x| x == ident)
+                }
+            }
+            _ => false,
+        }
+    }
+
+    pub fn raw_type_is_string(&self) -> bool {
+        match self.ty {
+            syn::Type::Path(ref p) => {
+                let path = &p.path;
+                path.leading_colon.is_none() && path.segments.len() == 1 && {
+                    let ident = &path.segments[0].ident.to_string();
+                    ["String"].iter().any(|&x| x == ident)
+                }
+            }
+            _ => false,
+        }
+    }
+
+    pub fn raw_type_is_bool(&self) -> bool {
+        match self.ty {
+            syn::Type::Path(ref p) => {
+                let path = &p.path;
+                path.leading_colon.is_none() && path.segments.len() == 1 && {
+                    let ident = &path.segments[0].ident.to_string();
+                    ["bool"].iter().any(|&x| x == ident)
+                }
+            }
+            _ => false,
+        }
+    }
+
+    pub fn is_list(&self) -> bool {
+        self.raw_type_is_list()
+        // || self.type_.as_ref().map_or(false, |t| t.deref().is_array())
+        // || self.link_many.is_some()
+    }
+
+    pub fn raw_type_is_list(&self) -> bool {
+        let ty = &self.ty;
+        match ty {
+            syn::Type::Path(path) => {
+                let last_seg = path
+                    .path
+                    .segments
+                    .last()
+                    .expect("Must have at least one segment");
+                if let syn::PathArguments::AngleBracketed(args) = &last_seg.arguments {
+                    if let Some(syn::GenericArgument::Type(syn::Type::Infer(_))) = args.args.first()
+                    {
+                        return false;
+                    }
+                    last_seg.ident == "Vec"
+                } else {
+                    false
+                }
+            }
+            syn::Type::Array(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn raw_type_is_optional(&self) -> bool {
+        let ty = &self.ty;
+        match ty {
+            syn::Type::Path(path) => {
+                let last_seg = path
+                    .path
+                    .segments
+                    .last()
+                    .expect("Must have at least one segment");
+                if let syn::PathArguments::AngleBracketed(args) = &last_seg.arguments {
+                    if let Some(syn::GenericArgument::Type(syn::Type::Infer(_))) = args.args.first()
+                    {
+                        return false;
+                    }
+                    last_seg.ident == "Option"
+                } else {
+                    false
+                }
+            }
+            syn::Type::Array(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn raw_type_is_hash_set(&self) -> bool {
+        let ty = &self.ty;
+        match ty {
+            syn::Type::Path(path) => {
+                let last_seg = path
+                    .path
+                    .segments
+                    .last()
+                    .expect("Must have at least one segment");
+                if let syn::PathArguments::AngleBracketed(args) = &last_seg.arguments {
+                    if let Some(syn::GenericArgument::Type(syn::Type::Infer(_))) = args.args.first()
+                    {
+                        return false;
+                    }
+                    last_seg.ident == "HashSet"
+                } else {
+                    false
+                }
+            }
+            syn::Type::Array(_) => false,
+            _ => false,
+        }
+    }
+
+    pub fn raw_type_is_object(&self) -> bool {
+        let ty = &self.ty;
+        match ty {
+            syn::Type::Path(path) => {
+                let last_seg = path
+                    .path
+                    .segments
+                    .last()
+                    .expect("Must have at least one segment");
+                if let syn::PathArguments::AngleBracketed(args) = &last_seg.arguments {
+                    if let Some(syn::GenericArgument::Type(syn::Type::Infer(_))) = args.args.first()
+                    {
+                        return false;
+                    }
+                    last_seg.ident == "HashMap" || last_seg.ident == "BTreeMap"
+                } else {
+                    false
+                }
+            }
+            syn::Type::Array(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn raw_type_is_datetime(&self) -> bool {
+        let ty = &self.ty;
+        match ty {
+            syn::Type::Path(type_path) => {
+                let last_segment = type_path
+                    .path
+                    .segments
+                    .last()
+                    .expect("Must have at least one segment");
+                last_segment.ident.to_string().to_lowercase() == "datetime"
+            }
+            _ => false,
+        }
+    }
+
+    pub fn raw_type_is_duration(&self) -> bool {
+        let ty = &self.ty;
+        match ty {
+            syn::Type::Path(type_path) => {
+                let last_segment = type_path
+                    .path
+                    .segments
+                    .last()
+                    .expect("Must have at least one segment");
+                last_segment.ident == "Duration"
+            }
+            _ => false,
+        }
+    }
+
+    pub fn raw_type_is_geometry(&self) -> bool {
+        let ty = &self.ty;
+        match ty {
+            syn::Type::Path(path) => {
+                let last_seg = path
+                    .path
+                    .segments
+                    .last()
+                    .expect("Must have at least one segment");
+                last_seg.ident == "Geometry"
+                    || last_seg.ident == "Point"
+                    || last_seg.ident == "LineString"
+                    || last_seg.ident == "Polygon"
+                    || last_seg.ident == "MultiPoint"
+                    || last_seg.ident == "MultiLineString"
+                    || last_seg.ident == "MultiPolygon"
+                    || last_seg.ident == "GeometryCollection"
+            }
+            syn::Type::Array(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn get_array_item_type(&self) -> Option<TokenStream> {
+        let ty = &self.ty;
+
+        // get_vector_item_type(ty).map(|t| t.into_token_stream())
+
+        let item_ty = match ty {
+            syn::Type::Path(type_path) => {
+                let last_segment = type_path
+                    .path
+                    .segments
+                    .last()
+                    .expect("Must have at least one segment");
+                if last_segment.ident != "Vec" {
+                    return None;
+                }
+                let item_ty = match last_segment.arguments {
+                    syn::PathArguments::AngleBracketed(ref args) => args.args.first(),
+                    _ => None,
+                };
+                match item_ty {
+                    Some(syn::GenericArgument::Type(ty)) => ty,
+                    _ => return None,
+                }
+            }
+            _ => return None,
+        };
+        Some(item_ty.clone().into_token_stream())
+    }
+
+    pub fn get_option_item_type(&self) -> Option<Type> {
+        let ty = &self.ty;
+
+        let item_ty = match ty {
+            syn::Type::Path(type_path) => {
+                let last_segment = type_path
+                    .path
+                    .segments
+                    .last()
+                    .expect("Must have at least one segment");
+                if last_segment.ident != "Option" {
+                    return None;
+                }
+                let item_ty = match last_segment.arguments {
+                    syn::PathArguments::AngleBracketed(ref args) => args.args.first(),
+                    _ => None,
+                };
+                match item_ty {
+                    Some(syn::GenericArgument::Type(ty)) => ty,
+                    _ => return None,
+                }
+            }
+            _ => return None,
+        };
+        Some(item_ty.clone())
+    }
+
+    pub fn infer_surreal_type_heuristically(
+        &self,
+        // ty: &Type,
+        // struct_name_ident_str: &String,
+        field_name_normalized: &str,
+    ) -> FieldTypeDerived {
+        let crate_name = get_crate_name(false);
+        let ty = &self.ty;
+
+        if self.raw_type_is_bool() {
+            FieldTypeDerived {
+                field_type: quote!(#crate_name::FieldType::Bool),
+                // field_item_type: None,
+                static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<::std::primitive::bool>);),
+            }
+        } else if self.raw_type_is_float() {
+            FieldTypeDerived {
+                field_type: quote!(#crate_name::FieldType::Float),
+                // field_item_type: None,
+                static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Number>);),
+            }
+        } else if self.raw_type_is_integer() {
+            FieldTypeDerived {
+                field_type: quote!(#crate_name::FieldType::Int),
+                // field_item_type: None,
+                static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Number>);),
+            }
+        } else if self.raw_type_is_string() {
+            FieldTypeDerived {
+                field_type: quote!(#crate_name::FieldType::String),
+                // field_item_type: None,
+                static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Strand>);),
+            }
+        // } else if self.raw_type_is_optional() || self.type_.is_some() {
+        } else if self.raw_type_is_optional() {
+            // let option_type = self.type_.as_ref().map(|ct| {
+            //     let ct = ct.to_string();
+            //     quote!(#ct.to_string().parse::<#crate_name::FieldType>().expect("Invalid db type"))
+            // });
+
+            let get_option_item_type = self.get_option_item_type();
+            let item = get_option_item_type
+                .clone()
+                .as_ref()
+                .map(|ct| {
+                    let ty = ct.clone();
+                    let item = Self {
+                        ty,
+                        attributes: Default::default(),
+                    };
+                    let item = item.infer_surreal_type_heuristically("");
+
+                    // let ct = ct.to_string();
+                    // quote!(#ct.to_string().parse::<#crate_name::FieldType>().expect("Invalid db type"))
+                    item
+                })
+                .unwrap_or_default();
+
+            let item_surreal_type = item.field_type;
+            let item_static_assertion = item.static_assertion;
+
+            FieldTypeDerived {
+                field_type: quote!(#crate_name::FieldType::Option(::std::boxed::Box::new(#item_surreal_type))),
+                // field_item_type: None,
+                static_assertion: quote!(
+                    #crate_name::validators::assert_option::<#ty>();
+                    #item_static_assertion
+                ),
+            }
+        } else if self.raw_type_is_list() {
+            // let array_item_type = match self.type_.as_ref() {
+            //     Some(FieldTypeWrapper(type_)) => type_.to_string(),
+            //     None => "Any".to_string(),
+            // };
+            // let array_type = self.type_.as_ref().map(|ct| {
+            //     let ct = ct.to_string();
+            //     quote!(#ct.to_string().parse::<#crate_name::FieldType>().expect("Invalid db type"))
+            // });
+
+            // let item_type = self.item_type.as_ref().map(|ct| {
+            //     let ct = ct.to_string();
+            //     quote!(#ct.to_string().parse::<#crate_name::FieldType>().expect("Invalid db type"))
+            // });
+            FieldTypeDerived {
+                field_type: quote!(#crate_name::FieldType::Array(::std::boxed::Box::new(#crate_name::FieldType::Any), ::std::option::Option::None)),
+                static_assertion: quote!(#crate_name::validators::assert_is_vec::<#ty>();),
+                // quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Array>);),
+            }
+        // } else if self.raw_type_is_hash_set() || self.type_.is_some() {
+        } else if self.raw_type_is_hash_set() {
+            // let array_type = self.type_.as_ref().map(|ct| {
+            //     let ct = ct.to_string();
+            //     quote!(#ct.to_string().parse::<#crate_name::FieldType>().expect("Invalid db type"))
+            // });
+
+            FieldTypeDerived {
+                field_type: quote!(#crate_name::FieldType::Set(::std::boxed::Box::new(#crate_name::FieldType::Any), ::std::option::Option::None)),
+                static_assertion: quote!(#crate_name::validators::assert_is_vec::<#ty>();),
+            }
+        } else if self.raw_type_is_object() {
+            FieldTypeDerived {
+                field_type: quote!(#crate_name::FieldType::Object),
+                static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Object>);),
+            }
+        } else if self.raw_type_is_duration() {
+            FieldTypeDerived {
+                field_type: quote!(#crate_name::FieldType::Duration),
+                static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Duration>);),
+            }
+        } else if self.raw_type_is_datetime() {
+            FieldTypeDerived {
+                field_type: quote!(#crate_name::FieldType::Datetime),
+                static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Datetime>);),
+            }
+        } else if self.raw_type_is_geometry() {
+            FieldTypeDerived {
+                // TODO: check if to auto-infer more speicific geometry type?
+                field_type: quote!(#crate_name::FieldType::Geometry(::std::vec![])),
+                static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Geometry>);),
+            }
+        } else if let Attributes {
+            link_one,
+            link_self,
+            link_many,
+            nest_array,
+            nest_object,
+            ..
+        } = self.attributes
+        {
+            if field_name_normalized == "id" {
+                FieldTypeDerived {
+                    field_type: quote!(#crate_name::FieldType::Record(::std::vec![Self::table_name()])),
+                    static_assertion: quote!(),
+                }
+                // TODO: Only do this for Edge
+            } else if field_name_normalized == "out" || field_name_normalized == "in" {
+                // An edge might be shared by multiple In/Out nodes. So, default to any type of
+                // record for edge in and out
+                FieldTypeDerived {
+                    field_type: quote!(#crate_name::FieldType::Record(::std::vec![])),
+                    static_assertion: quote!(),
+                }
+            } else if let Some(ref_node_type) = link_one.clone().or(link_self.clone()) {
+                let ref_node_type = format_ident!("{ref_node_type}");
+
+                FieldTypeDerived {
+                    field_type: quote!(#crate_name::FieldType::Record(::std::vec![#ref_node_type::table_name()])),
+                    static_assertion: quote!(),
+                }
+            } else if let Some(ref_node_type) = link_many {
+                let ref_struct_name = format_ident!("{ref_node_type}");
+                FieldTypeDerived {
+                    field_type: quote!(#crate_name::FieldType::Array(
+                        ::std::boxed::Box::new(#crate_name::FieldType::Record(::std::vec![#ref_struct_name::table_name()])),
+                        ::std::option::Option::None
+                    )),
+                    // field_item_type: Some(
+                    //     quote!(#crate_name::FieldType::Record(#ref_struct_name::table_name())),
+                    // ),
+                    static_assertion: quote!(),
+                }
+            } else if let Some(_ref_node_type) = nest_object {
+                FieldTypeDerived {
+                    field_type: quote!(#crate_name::FieldType::Object),
+                    static_assertion: quote!(),
+                }
+            } else if let Some(_ref_node_type) = nest_array {
+                FieldTypeDerived {
+                    field_type: quote!(#crate_name::FieldType::Array(
+                        ::std::boxed::Box::new(#crate_name::FieldType::Any),
+                        ::std::option::Option::None
+                    )),
+                    static_assertion: quote!(),
+                }
+            } else if let Some(_ref_node_type) = link_one {
+                FieldTypeDerived {
+                    // #crate_name::SurrealId<#foreign_node>
+                    field_type: quote!(#crate_name::FieldType::Record(::std::vec![_ref_node_type::table_name()])),
+                    static_assertion: quote!(),
+                }
+            } else if let Some(_ref_node_type) = link_self {
+                FieldTypeDerived {
+                    field_type: quote!(#crate_name::FieldType::Record(::std::vec![_ref_node_type::table_name()])),
+                    static_assertion: quote!(),
+                }
+            } else {
+                FieldTypeDerived {
+                    field_type: quote!(#crate_name::FieldType::Any),
+                    static_assertion: quote!(),
+                }
+            }
+        } else {
+            FieldTypeDerived {
+                field_type: quote!(#crate_name::FieldType::Any),
+                static_assertion: quote!(#crate_name::validators::assert_impl_one!(#ty: ::std::convert::Into<#crate_name::sql::Value>);),
+            }
+        }
+    }
+
+    pub fn type_is_inferrable(&self, field_name_normalized_str: &String) -> bool {
+        self.attributes.link_one.is_some()
+            || self.attributes.link_self.is_some()
+            || self.attributes.link_many.is_some()
+            || self.attributes.nest_object.is_some()
+            || self.attributes.nest_array.is_some()
+            || field_name_normalized_str == "id"
+            || field_name_normalized_str == "in"
+            || field_name_normalized_str == "out"
+            || self.raw_type_is_float()
+            || self.raw_type_is_integer()
+            || self.raw_type_is_string()
+            || self.raw_type_is_bool()
+            || self.raw_type_is_list()
+            || self.raw_type_is_hash_set()
+            || self.raw_type_is_object()
+            || self.raw_type_is_optional()
+            || self.raw_type_is_duration()
+            || self.raw_type_is_datetime()
+            || self.raw_type_is_geometry()
+    }
+}

--- a/derive/src/models/mod.rs
+++ b/derive/src/models/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod attributes;
 pub(crate) mod casing;
 pub(crate) mod edge;
 pub(crate) mod errors;
+pub(crate) mod field_rust_type;
 pub(crate) mod node;
 pub(crate) mod object;
 pub(crate) mod parser;

--- a/derive/src/models/parser.rs
+++ b/derive/src/models/parser.rs
@@ -813,14 +813,12 @@ impl SchemaFieldsProperties {
                         quote!(pub #field_ident_normalised: ::std::option::Option<#field_type>, ),
                     );
 
-                    let nesting_level = count_vec_nesting(&field_type);
+                    let nesting_level = count_vec_nesting(field_type);
                     let nested_vec_type = generate_nested_vec_type(&foreign_node, nesting_level);
 
                     store.static_assertions.push(quote! {
                         #crate_name::validators::assert_type_eq_all!(#field_type, #nested_vec_type);
                     });
-
-                    // store.static_assertions.push(quote!(#crate_name::validators::assert_type_eq_all!(#field_type, ::std::vec::Vec<#foreign_node>);));
 
                     update_field_names_fields_types_kv(Some(quote!(#foreign_node)));
                     get_nested_meta_with_defs(&node_object, true)
@@ -889,15 +887,7 @@ impl SchemaFieldsProperties {
                 .push(field_ident_normalised_as_str.to_owned());
         }
 
-        // let fields = data
-        //     .as_ref()
-        //     .take_struct()
-        //     .expect("Should never be enum")
-        //     .fields
-        //     .into_iter()
-        //     .fold(Self::default(), |mut store, field_receiver| {});
         Ok(store)
-        // Ok(fields)
     }
 }
 

--- a/derive/src/models/parser.rs
+++ b/derive/src/models/parser.rs
@@ -573,9 +573,9 @@ impl SchemaFieldsProperties {
                 };
 
                 // Only works for vectors
-                let array_trait = if field_receiver.is_list() {
+                let array_trait = if field_receiver.rust_type().is_list() {
                     array_element
-                        .or_else(||field_receiver.get_array_item_type())
+                        .or_else(||field_receiver.rust_type().get_array_item_type())
                         .or_else(|| {
                                 Some(field_receiver.get_fallback_array_item_concrete_type().map_err(|e| {
                                     // errors.push("Could not infer the type of the array. Please specify the type of the array. e.g: Vec<String> or Vec<Email>");
@@ -824,7 +824,7 @@ impl SchemaFieldsProperties {
                         quote!(pub #field_ident_normalised: ::std::option::Option<#field_type>, ),
                     );
 
-                    let ref_node_meta = if field_receiver.is_list() {
+                    let ref_node_meta = if field_receiver.rust_type().is_list() {
                         ReferencedNodeMeta::from_simple_array(field_ident_normalised)
                     } else {
                         ReferencedNodeMeta::default()

--- a/derive/src/models/parser.rs
+++ b/derive/src/models/parser.rs
@@ -444,13 +444,13 @@ impl SchemaFieldsProperties {
                     quote!(
                         impl #crate_name::SetterNumeric<#field_type> for self::#field_name_as_camel  {}
 
-                        impl From<self::#field_name_as_camel> for #crate_name::NumberLike {
+                        impl ::std::convert::From<self::#field_name_as_camel> for #crate_name::NumberLike {
                             fn from(val: self::#field_name_as_camel) -> Self {
                                 val.0.into()
                             }
                         }
 
-                        impl From<&self::#field_name_as_camel> for #crate_name::NumberLike {
+                        impl ::std::convert::From<&self::#field_name_as_camel> for #crate_name::NumberLike {
                             fn from(val: &self::#field_name_as_camel) -> Self {
                                 val.clone().0.into()
                             }
@@ -604,39 +604,39 @@ impl SchemaFieldsProperties {
                             #[derive(Debug, Clone)]
                             pub struct #field_name_as_camel(pub #crate_name::Field);
 
-                            impl From<&str> for #field_name_as_camel {
+                            impl ::std::convert::From<&str> for #field_name_as_camel {
                                 fn from(field_name: &str) -> Self {
                                     Self(#crate_name::Field::new(field_name))
                                 }
                             }
 
-                            impl From<#crate_name::Field> for #field_name_as_camel {
+                            impl ::std::convert::From<#crate_name::Field> for #field_name_as_camel {
                                 fn from(field_name: #crate_name::Field) -> Self {
                                     Self(field_name)
                                 }
                             }
 
-                            impl From<&#field_name_as_camel> for #crate_name::ValueLike {
+                            impl ::std::convert::From<&#field_name_as_camel> for #crate_name::ValueLike {
                                 fn from(value: &#field_name_as_camel) -> Self {
                                     let field: #crate_name::Field = value.into();
                                     field.into()
                                 }
                             }
 
-                            impl From<#field_name_as_camel> for #crate_name::ValueLike {
+                            impl ::std::convert::From<#field_name_as_camel> for #crate_name::ValueLike {
                                 fn from(value: #field_name_as_camel) -> Self {
                                     let field: #crate_name::Field = value.into();
                                     field.into()
                                 }
                             }
 
-                            impl From<&#field_name_as_camel> for #crate_name::Field {
+                            impl ::std::convert::From<&#field_name_as_camel> for #crate_name::Field {
                                 fn from(field_name:& #field_name_as_camel) -> Self {
                                     field_name.0.clone()
                                 }
                             }
 
-                            impl From<#field_name_as_camel> for #crate_name::Field {
+                            impl ::std::convert::From<#field_name_as_camel> for #crate_name::Field {
                                 fn from(field_name: #field_name_as_camel) -> Self {
                                     field_name.0
                                 }
@@ -656,13 +656,13 @@ impl SchemaFieldsProperties {
                                 }
                             }
 
-                            impl<T: #crate_name::serde::Serialize> From<self::#field_name_as_camel> for #crate_name::SetterArg<T> {
+                            impl<T: #crate_name::serde::Serialize> ::std::convert::From<self::#field_name_as_camel> for #crate_name::SetterArg<T> {
                                 fn from(value: self::#field_name_as_camel) -> Self {
                                     Self::Field(value.into())
                                 }
                             }
 
-                            impl<T: #crate_name::serde::Serialize> From<&self::#field_name_as_camel> for #crate_name::SetterArg<T> {
+                            impl<T: #crate_name::serde::Serialize> ::std::convert::From<&self::#field_name_as_camel> for #crate_name::SetterArg<T> {
                                 fn from(value: &self::#field_name_as_camel) -> Self {
                                     Self::Field(value.into())
                                 }
@@ -1176,7 +1176,7 @@ impl NodeEdgeMetadataStore {
                     pub struct #edge_name_as_struct_with_direction_ident(#edge_name_as_struct_original_ident);
 
 
-                    impl From<#edge_name_as_struct_original_ident> for #edge_name_as_struct_with_direction_ident {
+                    impl ::std::convert::From<#edge_name_as_struct_original_ident> for #edge_name_as_struct_with_direction_ident {
                         fn from(value: #edge_name_as_struct_original_ident) -> Self {
                             Self(value)
                         }

--- a/derive/src/models/parser.rs
+++ b/derive/src/models/parser.rs
@@ -573,7 +573,7 @@ impl SchemaFieldsProperties {
                 };
 
                 // Only works for vectors
-                let array_trait = if field_receiver.rust_type().is_list() {
+                let array_trait = if field_receiver.is_list() {
                     array_element
                         .or_else(||field_receiver.rust_type().get_array_inner_type().map(|inner| inner.into_token_stream()))
                         .or_else(|| {

--- a/derive/src/models/parser.rs
+++ b/derive/src/models/parser.rs
@@ -575,7 +575,7 @@ impl SchemaFieldsProperties {
                 // Only works for vectors
                 let array_trait = if field_receiver.rust_type().is_list() {
                     array_element
-                        .or_else(||field_receiver.rust_type().get_array_item_type())
+                        .or_else(||field_receiver.rust_type().get_array_inner_type().map(|inner| inner.into_token_stream()))
                         .or_else(|| {
                                 Some(field_receiver.get_fallback_array_item_concrete_type().map_err(|e| {
                                     // errors.push("Could not infer the type of the array. Please specify the type of the array. e.g: Vec<String> or Vec<Email>");

--- a/derive/src/models/utils.rs
+++ b/derive/src/models/utils.rs
@@ -1,3 +1,10 @@
+/*
+ * Author: Oyelowo Oyedayo
+ * Email: oyelowo.oss@gmail.com
+ * Copyright (c) 2023 Oyelowo Oyedayo
+ * Licensed under the MIT license
+ */
+
 use proc_macro2::{Span, TokenStream, TokenTree};
 use proc_macro_crate::{crate_name, FoundCrate};
 use quote::quote;

--- a/derive/src/models/utils.rs
+++ b/derive/src/models/utils.rs
@@ -28,3 +28,45 @@ pub fn get_crate_name(internal: bool) -> TokenStream {
         TokenTree::from(Ident::new(&name, Span::call_site())).into()
     }
 }
+
+pub fn generate_nested_vec_type(
+    foreign_node: &syn::Ident,
+    nesting_level: usize,
+) -> proc_macro2::TokenStream {
+    if nesting_level == 0 {
+        quote!(#foreign_node)
+    } else {
+        let inner_type = generate_nested_vec_type(foreign_node, nesting_level - 1);
+        quote!(::std::vec::Vec<#inner_type>)
+    }
+}
+
+pub fn count_vec_nesting(field_type: &syn::Type) -> usize {
+    match field_type {
+        syn::Type::Path(type_path) => {
+            // Check if the outermost type is a `Vec`.
+            if let Some(segment) = type_path.path.segments.last() {
+                if segment.ident == "Vec" {
+                    // It's a Vec, now look at the inner type.
+                    if let syn::PathArguments::AngleBracketed(angle_args) = &segment.arguments {
+                        if let Some(syn::GenericArgument::Type(inner_type)) =
+                            angle_args.args.first()
+                        {
+                            // Recursively count nesting inside the Vec.
+                            1 + count_vec_nesting(inner_type)
+                        } else {
+                            0 // No type inside Vec's angle brackets.
+                        }
+                    } else {
+                        0 // Vec has no angle brackets, which should not happen for valid Vec usage.
+                    }
+                } else {
+                    0 // The outermost type is not a Vec.
+                }
+            } else {
+                0 // No segments in the type path.
+            }
+        }
+        _ => 0, // Not a type path, so it can't be a Vec.
+    }
+}

--- a/derive/src/query/mod.rs
+++ b/derive/src/query/mod.rs
@@ -1,3 +1,10 @@
+/*
+ * Author: Oyelowo Oyedayo
+ * Email: oyelowo.oss@gmail.com
+ * Copyright (c) 2023 Oyelowo Oyedayo
+ * Licensed under the MIT license
+ */
+
 use proc_macro2::{Ident, Span, TokenStream, TokenTree};
 use quote::ToTokens;
 use surreal_query_builder::sql;

--- a/migrator-tests/tests/snapshots/generate__oneway_migrations-12.snap
+++ b/migrator-tests/tests/snapshots/generate__oneway_migrations-12.snap
@@ -8,7 +8,7 @@ expression: fields_info.unwrap()
         "createdAt": "DEFINE FIELD createdAt ON planet TYPE datetime",
         "firstName": "DEFINE FIELD firstName ON planet TYPE string",
         "id": "DEFINE FIELD id ON planet TYPE record<planet>",
-        "labels": "DEFINE FIELD labels ON planet TYPE array",
+        "labels": "DEFINE FIELD labels ON planet TYPE array<string>",
         "population": "DEFINE FIELD population ON planet TYPE int",
         "updatedAt": "DEFINE FIELD updatedAt ON planet TYPE datetime",
     },

--- a/migrator-tests/tests/snapshots/generate__oneway_migrations-4.snap
+++ b/migrator-tests/tests/snapshots/generate__oneway_migrations-4.snap
@@ -8,7 +8,7 @@ expression: fields_info.unwrap()
         "event2": "DEFINE EVENT event2 ON animal WHEN (species = 'Homo Sapien') AND (velocity < 10) THEN (SELECT * FROM eats)",
     },
     "fields": {
-        "attributes": "DEFINE FIELD attributes ON animal TYPE array",
+        "attributes": "DEFINE FIELD attributes ON animal TYPE array<string>",
         "createdAt": "DEFINE FIELD createdAt ON animal TYPE datetime",
         "id": "DEFINE FIELD id ON animal TYPE record<animal>",
         "species": "DEFINE FIELD species ON animal TYPE string",

--- a/models/src/models/alien.rs
+++ b/models/src/models/alien.rs
@@ -28,10 +28,7 @@ pub struct Alien {
     pub weapon: LinkOne<Weapon>,
 
     // Again, we dont have to provide the type attribute, it can auto detect
-    #[surreal_orm(
-        link_many = "SpaceShip",
-        // type_ = "array",
-    )]
+    #[surreal_orm(link_many = "SpaceShip")]
     pub space_ships: LinkMany<SpaceShip>,
 
     // This is a read only field

--- a/models/src/models/weapon.rs
+++ b/models/src/models/weapon.rs
@@ -75,9 +75,11 @@ pub struct TestStuff {
     pub id: SurrealSimpleId<Self>,
     #[surreal_orm(type_ = "option<string>")]
     pub amt: Option<Strength>,
-    // #[surreal_orm(type_ = "option<geometry<polygon>>")]
-    pub amt2: Option<i32>,
-    // #[surreal_orm(type_ = "int")]
-    // pub amt3: Strength,
+    pub amt9: Option<Strength>,
+    // Would be autoinferred
+    pub amt2: Option<u64>,
+    #[surreal_orm(type_ = "array<int>")]
     pub amt3: Vec<u64>,
+    // #[surreal_orm(type_ = "int")]
+    pub count: u64,
 }

--- a/models/src/models/weapon.rs
+++ b/models/src/models/weapon.rs
@@ -73,6 +73,11 @@ pub struct Balance {
 #[surreal_orm(table_name = "test_stuff")]
 pub struct TestStuff {
     pub id: SurrealSimpleId<Self>,
-    // #[surreal_orm(type_ = "option<int>")]
-    pub amt: Option<u64>,
+    #[surreal_orm(type_ = "option<string>")]
+    pub amt: Option<Strength>,
+    #[surreal_orm(type_ = "option<geometry<polygon>>")]
+    pub amt2: Option<i32>,
+    #[surreal_orm(type_ = "int")]
+    pub amt3: Strength,
 }
+// DEFINE FIELD amt TYPE option<int> on TABLE test_stuff;

--- a/models/src/models/weapon.rs
+++ b/models/src/models/weapon.rs
@@ -75,9 +75,9 @@ pub struct TestStuff {
     pub id: SurrealSimpleId<Self>,
     #[surreal_orm(type_ = "option<string>")]
     pub amt: Option<Strength>,
-    #[surreal_orm(type_ = "option<geometry<polygon>>")]
+    // #[surreal_orm(type_ = "option<geometry<polygon>>")]
     pub amt2: Option<i32>,
-    #[surreal_orm(type_ = "int")]
-    pub amt3: Strength,
+    // #[surreal_orm(type_ = "int")]
+    // pub amt3: Strength,
+    pub amt3: Vec<u64>,
 }
-// DEFINE FIELD amt TYPE option<int> on TABLE test_stuff;

--- a/models/src/models/weapon.rs
+++ b/models/src/models/weapon.rs
@@ -73,8 +73,9 @@ pub struct Balance {
 #[surreal_orm(table_name = "test_stuff")]
 pub struct TestStuff {
     pub id: SurrealSimpleId<Self>,
-    #[surreal_orm(type_ = "option<string>")]
+    #[surreal_orm(type_ = "option<int>")]
     pub amt: Option<Strength>,
+    #[surreal_orm(type_ = "option<int>")]
     pub amt9: Option<Strength>,
     // Would be autoinferred
     pub amt2: Option<u64>,

--- a/models/src/models/weapon.rs
+++ b/models/src/models/weapon.rs
@@ -64,5 +64,15 @@ pub struct Account {
 #[surreal_orm(table_name = "balance")]
 pub struct Balance {
     pub id: SurrealId<Self, String>,
+    #[surreal_orm(type_ = "option<string>")]
     pub amount: f64,
+}
+
+#[derive(Node, Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+#[surreal_orm(table_name = "test_stuff")]
+pub struct TestStuff {
+    pub id: SurrealSimpleId<Self>,
+    // #[surreal_orm(type_ = "option<int>")]
+    pub amt: Option<u64>,
 }

--- a/orm-tests/tests/edge_attributes.rs
+++ b/orm-tests/tests/edge_attributes.rs
@@ -38,7 +38,7 @@ DEFINE FIELD lifeExpectancy ON TABLE visits TYPE duration;
 DEFINE FIELD linePolygon ON TABLE visits TYPE geometry;
 DEFINE FIELD territoryArea ON TABLE visits TYPE geometry;
 DEFINE FIELD home ON TABLE visits TYPE geometry;
-DEFINE FIELD tags ON TABLE visits TYPE array<any>;
+DEFINE FIELD tags ON TABLE visits TYPE array<string>;
 DEFINE FIELD weapon ON TABLE visits TYPE record<weapon>;
 DEFINE FIELD spaceShips ON TABLE visits TYPE array<record<space_ship>>;"
     );

--- a/orm-tests/tests/geometry.rs
+++ b/orm-tests/tests/geometry.rs
@@ -41,6 +41,8 @@ struct Company {
     founded: chrono::DateTime<chrono::Utc>,
     #[surreal_orm(nest_array = "Person")]
     founders: Vec<Person>,
+    #[surreal_orm(nest_array = "Person")]
+    founders_multiple_nesting: Vec<Vec<Person>>,
     tags: Vec<String>,
     home: geo::Point,
 }
@@ -366,6 +368,24 @@ async fn insert_many() -> surrealdb::Result<()> {
                     name: "Jane Doe".to_string(),
                 },
             ],
+            founders_multiple_nesting: vec![
+                vec![
+                    Person {
+                        name: "John Doe".to_string(),
+                    },
+                    Person {
+                        name: "Jane Doe".to_string(),
+                    },
+                ],
+                vec![
+                    Person {
+                        name: "John Doe".to_string(),
+                    },
+                    Person {
+                        name: "Jane Doe".to_string(),
+                    },
+                ],
+            ],
             tags: vec!["foo".to_string(), "bar".to_string()],
             home: (45.3, 78.1).into(),
         },
@@ -387,6 +407,7 @@ async fn insert_many() -> surrealdb::Result<()> {
                     name: "Jane Doe".to_string(),
                 },
             ],
+            founders_multiple_nesting: vec![],
             tags: vec!["foo".to_string(), "bar".to_string()],
             home: (63.0, 21.0).into(),
         },
@@ -422,6 +443,7 @@ async fn insert_from_select_query() -> surrealdb::Result<()> {
                     name: "Jane Doe".to_string(),
                 },
             ],
+            founders_multiple_nesting: vec![],
             tags: vec!["foo".to_string(), "bar".to_string()],
             home: (45.3, 78.1).into(),
         },
@@ -443,6 +465,7 @@ async fn insert_from_select_query() -> surrealdb::Result<()> {
                     name: "Jane Doe".to_string(),
                 },
             ],
+            founders_multiple_nesting: vec![],
             tags: vec!["foo".to_string(), "bar".to_string()],
             home: (63.0, 21.0).into(),
         },

--- a/orm-tests/tests/geometry.rs
+++ b/orm-tests/tests/geometry.rs
@@ -31,6 +31,7 @@ use geo::Coord;
 pub struct Person {
     name: String,
 }
+
 #[derive(Node, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 #[surreal_orm(table_name = "company")]
@@ -38,6 +39,7 @@ struct Company {
     id: SurrealId<Self, i32>,
     name: String,
     founded: chrono::DateTime<chrono::Utc>,
+    #[surreal_orm(nest_array = "Person")]
     founders: Vec<Person>,
     tags: Vec<String>,
     home: geo::Point,
@@ -50,6 +52,7 @@ struct GenZCompany {
     id: SurrealSimpleId<Self>,
     name: String,
     founded: chrono::DateTime<chrono::Utc>,
+    #[surreal_orm(nest_array = "Person")]
     founders: Vec<Person>,
     tags: Vec<String>,
     home: geo::Point,

--- a/orm-tests/tests/node_attributes.rs
+++ b/orm-tests/tests/node_attributes.rs
@@ -37,7 +37,7 @@ DEFINE FIELD lifeExpectancy ON TABLE alien TYPE duration;
 DEFINE FIELD linePolygon ON TABLE alien TYPE geometry;
 DEFINE FIELD territoryArea ON TABLE alien TYPE geometry;
 DEFINE FIELD home ON TABLE alien TYPE geometry;
-DEFINE FIELD tags ON TABLE alien TYPE array<any>;
+DEFINE FIELD tags ON TABLE alien TYPE array<string>;
 DEFINE FIELD ally ON TABLE alien TYPE record<alien>;
 DEFINE FIELD weapon ON TABLE alien TYPE record<weapon>;
 DEFINE FIELD spaceShips ON TABLE alien TYPE array<record<space_ship>>;"

--- a/orm-tests/tests/snapshots/geometry__company_field_definitions.snap
+++ b/orm-tests/tests/snapshots/geometry__company_field_definitions.snap
@@ -1,0 +1,12 @@
+---
+source: orm-tests/tests/geometry.rs
+expression: company_defs
+---
+DEFINE FIELD id ON TABLE company TYPE record<company>;
+DEFINE FIELD name ON TABLE company TYPE string;
+DEFINE FIELD founded ON TABLE company TYPE datetime;
+DEFINE FIELD founders ON TABLE company TYPE array<object>;
+DEFINE FIELD foundersMultipleNesting ON TABLE company TYPE array<array<object>>;
+DEFINE FIELD founders10 ON TABLE company TYPE array<array<array<array<array<array<array<array<array<array<object>>>>>>>>>>;
+DEFINE FIELD tags ON TABLE company TYPE array<string>;
+DEFINE FIELD home ON TABLE company TYPE geometry;

--- a/orm-tests/tests/snapshots/geometry__geom_collection.snap
+++ b/orm-tests/tests/snapshots/geometry__geom_collection.snap
@@ -1,5 +1,5 @@
 ---
-source: surreal-orm-tests/tests/geometry.rs
+source: orm-tests/tests/geometry.rs
 expression: geom
 ---
 TestGeometrycollection {
@@ -14,26 +14,30 @@ TestGeometrycollection {
         PhantomData<i32>,
     ),
     home_geometrycollection: [
-        Point(
+        GeometryCollection(
             Point(
-                Coord {
-                    x: 0.0,
-                    y: 0.0,
-                },
+                Point(
+                    Coord {
+                        x: 0.0,
+                        y: 0.0,
+                    },
+                ),
             ),
         ),
-        LineString(
+        GeometryCollection(
             LineString(
-                [
-                    Coord {
-                        x: 1.0,
-                        y: 1.0,
-                    },
-                    Coord {
-                        x: 2.0,
-                        y: 2.0,
-                    },
-                ],
+                LineString(
+                    [
+                        Coord {
+                            x: 1.0,
+                            y: 1.0,
+                        },
+                        Coord {
+                            x: 2.0,
+                            y: 2.0,
+                        },
+                    ],
+                ),
             ),
         ),
     ],

--- a/orm-tests/tests/snapshots/geometry__insert_from_select_query.snap
+++ b/orm-tests/tests/snapshots/geometry__insert_from_select_query.snap
@@ -1,5 +1,5 @@
 ---
-source: surreal-orm-tests/tests/geometry.rs
+source: orm-tests/tests/geometry.rs
 expression: selected_original
 ---
 [
@@ -24,6 +24,7 @@ expression: selected_original
                 name: "Jane Doe",
             },
         ],
+        founders_multiple_nesting: [],
         tags: [
             "foo",
             "bar",
@@ -56,6 +57,7 @@ expression: selected_original
                 name: "Jane Doe",
             },
         ],
+        founders_multiple_nesting: [],
         tags: [
             "foo",
             "bar",

--- a/orm-tests/tests/snapshots/geometry__insert_from_select_query.snap
+++ b/orm-tests/tests/snapshots/geometry__insert_from_select_query.snap
@@ -25,6 +25,7 @@ expression: selected_original
             },
         ],
         founders_multiple_nesting: [],
+        founders_10: [],
         tags: [
             "foo",
             "bar",
@@ -58,6 +59,7 @@ expression: selected_original
             },
         ],
         founders_multiple_nesting: [],
+        founders_10: [],
         tags: [
             "foo",
             "bar",

--- a/orm-tests/tests/snapshots/geometry__insert_many.snap
+++ b/orm-tests/tests/snapshots/geometry__insert_many.snap
@@ -42,6 +42,7 @@ expression: results
                 },
             ],
         ],
+        founders_10: [],
         tags: [
             "foo",
             "bar",
@@ -75,6 +76,7 @@ expression: results
             },
         ],
         founders_multiple_nesting: [],
+        founders_10: [],
         tags: [
             "foo",
             "bar",

--- a/orm-tests/tests/snapshots/geometry__insert_many.snap
+++ b/orm-tests/tests/snapshots/geometry__insert_many.snap
@@ -1,5 +1,5 @@
 ---
-source: surreal-orm-tests/tests/geometry.rs
+source: orm-tests/tests/geometry.rs
 expression: results
 ---
 [
@@ -23,6 +23,24 @@ expression: results
             Person {
                 name: "Jane Doe",
             },
+        ],
+        founders_multiple_nesting: [
+            [
+                Person {
+                    name: "John Doe",
+                },
+                Person {
+                    name: "Jane Doe",
+                },
+            ],
+            [
+                Person {
+                    name: "John Doe",
+                },
+                Person {
+                    name: "Jane Doe",
+                },
+            ],
         ],
         tags: [
             "foo",
@@ -56,6 +74,7 @@ expression: results
                 name: "Jane Doe",
             },
         ],
+        founders_multiple_nesting: [],
         tags: [
             "foo",
             "bar",

--- a/query-builder/src/validators/mod.rs
+++ b/query-builder/src/validators/mod.rs
@@ -89,6 +89,15 @@ pub fn assert_same_length_arrays<T, const N: usize>(_array1: [T; N], _array2: [T
     println!("Both arrays have the same length of {}", N);
 }
 
+trait IsOption {}
+
+// Implement the trait for all `Option<T>`.
+impl<T> IsOption for Option<T> {}
+
+fn assert_option<T: IsOption>() {
+    // This function doesn't need to do anything; it's just here to enforce the type constraint.
+}
+
 /// Checks that all idents are unique.
 #[macro_export]
 macro_rules! check_unique_idents {

--- a/query-builder/src/validators/mod.rs
+++ b/query-builder/src/validators/mod.rs
@@ -89,12 +89,13 @@ pub fn assert_same_length_arrays<T, const N: usize>(_array1: [T; N], _array2: [T
     println!("Both arrays have the same length of {}", N);
 }
 
-trait IsOption {}
+/// check if a type is an Option
+pub trait IsOption {}
 
-// Implement the trait for all `Option<T>`.
 impl<T> IsOption for Option<T> {}
 
-fn assert_option<T: IsOption>() {
+/// Validate that type is an Option at compile time
+pub fn assert_option<T: IsOption>() {
     // This function doesn't need to do anything; it's just here to enforce the type constraint.
 }
 

--- a/query-builder/src/validators/mod.rs
+++ b/query-builder/src/validators/mod.rs
@@ -99,6 +99,15 @@ pub fn assert_option<T: IsOption>() {
     // This function doesn't need to do anything; it's just here to enforce the type constraint.
 }
 
+/// Check if a type is an array
+pub trait IsArray {}
+
+impl<T> IsArray for Vec<T> {}
+
+/// Validate that type is an Vec at compile time
+pub fn assert_vec<T: IsArray>() {
+    // This function doesn't need to do anything; it's just here to enforce the type constraint.
+}
 /// Checks that all idents are unique.
 #[macro_export]
 macro_rules! check_unique_idents {


### PR DESCRIPTION
This update is all about smarter type inference, stronger compile-time checks, and cleaner, more maintainable code structures. These advancements will streamline your development workflow and improve the robustness of your applications. Changes include:

- **Type Inference Enhancements**:   can now infer optional field types, array content types, and complex nested vector types, streamlining the development process by reducing the need for explicit type annotations.

- **Compile-Time Assertions**: New compile-time validators have been implemented to assert the presence of options and vectors, enhancing type safety and reducing the risk of runtime errors.

- **Static Assertions for Vec Fields**: Static assertions have been added for Vec field inner types, providing an additional layer of type checking at compile time.

- **Support for Nested Vectors**: The macro now supports multiple nested vectors of surreal objects, allowing for more complex data structures to be easily handled within queries.


- **Path Clarification**: The full path for the `convert-From` trait has been specified, ensuring clarity and avoiding any potential conflicts or ambiguities in the codebase.

- **Refactoring and Cleanup**: The code has undergone significant refactoring and cleanup, improving readability and maintainability. This includes better heuristics for checking field types and removing unnecessary code.

- **Test Updates**: Geometry collection tests have been updated to reflect the new changes, ensuring that all features work as expected.

- **Examples and Demonstrations**: Additional examples of auto-inferred types have been provided, showcasing the macro's enhanced capabilities.


```rs
#[derive(Node, Serialize, Deserialize, Debug, Clone, Default)]
#[serde(rename_all = "camelCase")]
#[surreal_orm(table_name = "test_stuff")]
pub struct TestStuff {
    pub id: SurrealSimpleId<Self>,
    #[surreal_orm(type_ = "option<string>")]
    pub amt: Option<Strength>,

    // Would be throw a compile-time error since we cannot directly guess the 'Strength' type from the AST. Use explicit type if you want. You can use `#[surreal_orm(type_ = "int")]` to fix this. You can also use the type - "any"
    pub amt2: Option<Strength>,

    // Would be autoinferred as option<int>
    pub amt3: Option<u64>,

     // Inner type is now autoinferred as vec<int>
    pub amt4: Vec<u64>,

    pub count: u64,
}




#[derive(Node, Debug, Serialize, Deserialize, Clone)]
#[serde(rename_all = "camelCase")]
#[surreal_orm(table_name = "company")]
struct Company {
    id: SurrealId<Self, i32>,

    // Now works 
    #[surreal_orm(nest_array = "Person")]
    founders: Vec<Person>,

    // Now works
    #[surreal_orm(nest_array = "Person")]
    founders_multiple_nesting: Vec<Vec<Person>>,


    #[surreal_orm(nest_array = "Person")]
    founders: Vec<Person>,

    #[surreal_orm(nest_array = "Person")]
    founders_multiple_nesting: Vec<Vec<Person>>,

    #[surreal_orm(nest_array = "Person")]
    founders_10: Vec<Vec<Vec<Vec<Vec<Vec<Vec<Vec<Vec<Vec<Person>>>>>>>>>>,

}


```
